### PR TITLE
Add mystery rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Bombtag has a few options you can use to configure and tweak the gameplay. They'
 - `bombtag_hammer_freeze`, The amount of ticks of freeze inflicted when hitting an alive player. (0 to disable). Default: 50
 - `bombtag_bomb_weapon`, Which weapon should the bomb be given? 0 - Hammer, 1 - Gun, 2 - Shotgun, 3 - Grenade, 4 - Laser, 5 - Ninja. Default: 0
 - `bombtag_seconds_to_explosion`, The minimum amount of seconds a tee's bomb timer will have after getting bomb. Default: 1
+- `bombtag_mystery_chance`, The percentage of a mystery round happening! A random line from sv_mysteryrounds_filename will be executed. Default: 0
+- `sv_mysteryrounds_filename`, File which contains mystery round commands, one round per line. Default: ""
+- `sv_mysteryrounds_reset_filename`, File which contains the commands to execute after a mystery round. Default: ""
 
 ## Building
 This mod is based on DDRaceNetwork. You can use their instructions to learn how to build the project, [ddnet/ddnet](https://github.com/ddnet/ddnet).

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -275,6 +275,8 @@ public:
 	virtual bool DnsblBlack(int ClientId) = 0;
 	virtual const char *GetAnnouncementLine() = 0;
 	virtual void ReadAnnouncementsFile(const char *pFileName) = 0;
+	virtual const char *GetMysteryRoundLine() = 0;
+	virtual void ReadMysteryRoundsFile(const char *pFileName) = 0;
 	virtual bool ClientPrevIngame(int ClientId) = 0;
 	virtual const char *GetNetErrorString(int ClientId) = 0;
 	virtual void ResetNetErrorString(int ClientId) = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2787,6 +2787,7 @@ int CServer::Run()
 	}
 
 	ReadAnnouncementsFile(g_Config.m_SvAnnouncementFileName);
+	ReadMysteryRoundsFile(g_Config.m_SvMysteryRoundsFileName);
 
 	// process pending commands
 	m_pConsole->StoreCommands(false);
@@ -3827,6 +3828,17 @@ void CServer::ConchainAnnouncementFileName(IConsole::IResult *pResult, void *pUs
 	}
 }
 
+void CServer::ConchainMysteryRoundsFileName(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	CServer *pSelf = (CServer *)pUserData;
+	bool Changed = pResult->NumArguments() && str_comp(pResult->GetString(0), g_Config.m_SvMysteryRoundsFileName);
+	pfnCallback(pResult, pCallbackUserData);
+	if(Changed)
+	{
+		pSelf->ReadMysteryRoundsFile(g_Config.m_SvMysteryRoundsFileName);
+	}
+}
+
 #if defined(CONF_FAMILY_UNIX)
 void CServer::ConchainConnLoggingServerChange(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
 {
@@ -3999,6 +4011,52 @@ const char *CServer::GetAnnouncementLine()
 	}
 
 	return m_vAnnouncements[m_AnnouncementLastLine].c_str();
+}
+
+void CServer::ReadMysteryRoundsFile(const char *pFileName)
+{
+	m_vMysteryRounds.clear();
+
+	if(pFileName[0] == '\0')
+		return;
+
+	CLineReader LineReader;
+	if(!LineReader.OpenFile(m_pStorage->OpenFile(pFileName, IOFLAG_READ, IStorage::TYPE_ALL)))
+	{
+		dbg_msg("bombtag", "failed to open '%s'", pFileName);
+		return;
+	}
+	while(const char *pLine = LineReader.Get())
+	{
+		if(str_length(pLine) && pLine[0] != '#')
+		{
+			m_vMysteryRounds.emplace_back(pLine);
+		}
+	}
+}
+
+const char *CServer::GetMysteryRoundLine()
+{
+	if(m_vMysteryRounds.empty())
+	{
+		return 0;
+	}
+	else if(m_vMysteryRounds.size() == 1)
+	{
+		m_MysteryRoundLastLine = 0;
+	}
+	else
+	{
+		unsigned Rand;
+		do
+		{
+			Rand = rand() % m_vMysteryRounds.size();
+		} while(Rand == m_MysteryRoundLastLine);
+
+		m_MysteryRoundLastLine = Rand;
+	}
+
+	return m_vMysteryRounds[m_MysteryRoundLastLine].c_str();
 }
 
 int *CServer::GetIdMap(int ClientId)

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -260,6 +260,9 @@ public:
 	size_t m_AnnouncementLastLine;
 	std::vector<std::string> m_vAnnouncements;
 
+	size_t m_MysteryRoundLastLine;
+	std::vector<std::string> m_vMysteryRounds;
+
 	std::shared_ptr<ILogger> m_pFileLogger = nullptr;
 	std::shared_ptr<ILogger> m_pStdoutLogger = nullptr;
 
@@ -427,6 +430,7 @@ public:
 	static void ConchainLoglevel(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainStdoutOutputLevel(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainAnnouncementFileName(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainMysteryRoundsFileName(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
 #if defined(CONF_FAMILY_UNIX)
 	static void ConchainConnLoggingServerChange(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
@@ -445,6 +449,9 @@ public:
 	int m_aPrevStates[MAX_CLIENTS];
 	const char *GetAnnouncementLine() override;
 	void ReadAnnouncementsFile(const char *pFileName) override;
+
+	const char *GetMysteryRoundLine() override;
+	void ReadMysteryRoundsFile(const char *pFileName) override;
 
 	int *GetIdMap(int ClientId) override;
 

--- a/src/engine/shared/bomb_config_variables.h
+++ b/src/engine/shared/bomb_config_variables.h
@@ -21,4 +21,8 @@ MACRO_CONFIG_INT(BombtagBombDamage, bombtag_bomb_damage, 1, 0, 100, CFGFLAG_SERV
 MACRO_CONFIG_INT(BombtagHammerFreeze, bombtag_hammer_freeze, 50, 0, 100000, CFGFLAG_SERVER, "The amount of ticks of freeze inflicted when hitting an alive player. (0 to disable)")
 MACRO_CONFIG_INT(BombtagBombWeapon, bombtag_bomb_weapon, 0, 0, 5, CFGFLAG_SERVER, "Which weapon should the bomb be given? 0 - Hammer, 1 - Gun, 2 - Shotgun, 3 - Grenade, 4 - Laser, 5 - Ninja")
 
+MACRO_CONFIG_INT(BombtagMysteryChance, bombtag_mystery_chance, 0, 0, 100, CFGFLAG_SERVER, "The percentage of a mystery round happening! A random line from sv_mysteryrounds_filename will be executed.")
+MACRO_CONFIG_STR(SvMysteryRoundsFileName, sv_mysteryrounds_filename, IO_MAX_PATH_LENGTH, "", CFGFLAG_SERVER, "File which contains mystery round commands, one round per line.")
+MACRO_CONFIG_STR(SvMysteryRoundsResetFileName, sv_mysteryrounds_reset_filename, IO_MAX_PATH_LENGTH, "", CFGFLAG_SERVER, "File which contains the commands to execute after a mystery round.")
+
 #endif

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -899,6 +899,12 @@ void CGameContext::ConReloadAnnouncement(IConsole::IResult *pResult, void *pUser
 	pSelf->Server()->ReadAnnouncementsFile(g_Config.m_SvAnnouncementFileName);
 }
 
+void CGameContext::ConReloadMysteryRounds(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	pSelf->Server()->ReadMysteryRoundsFile(g_Config.m_SvMysteryRoundsFileName);
+}
+
 void CGameContext::ConDumpAntibot(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3693,6 +3693,7 @@ void CGameContext::OnConsoleInit()
 	Console()->Register("hot_reload", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConHotReload, this, "Reload the map while preserving the state of tees and teams");
 	Console()->Register("reload_censorlist", "", CFGFLAG_SERVER, ConReloadCensorlist, this, "Reload the censorlist");
 	Console()->Register("reload_announcement", "", CFGFLAG_SERVER, ConReloadAnnouncement, this, "Reload the announcements");
+	Console()->Register("reload_mysteryrounds", "", CFGFLAG_SERVER, ConReloadMysteryRounds, this, "Reload the mystery rounds");
 
 	Console()->Register("add_vote", "s[name] r[command]", CFGFLAG_SERVER, ConAddVote, this, "Add a voting option");
 	Console()->Register("remove_vote", "r[name]", CFGFLAG_SERVER, ConRemoveVote, this, "remove a voting option");

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -521,6 +521,8 @@ private:
 	static void ConReloadCensorlist(IConsole::IResult *pResult, void *pUserData);
 	static void ConReloadAnnouncement(IConsole::IResult *pResult, void *pUserData);
 
+	static void ConReloadMysteryRounds(IConsole::IResult *pResult, void *pUserData);
+
 	CCharacter *GetPracticeCharacter(IConsole::IResult *pResult);
 
 	enum

--- a/src/game/server/gamemodes/Bomb.cpp
+++ b/src/game/server/gamemodes/Bomb.cpp
@@ -1,4 +1,6 @@
 #include "Bomb.h"
+#include "base/system.h"
+#include <engine/shared/linereader.h>
 #include <base/color.h>
 #include <engine/shared/config.h>
 #include <engine/shared/protocol.h>
@@ -438,6 +440,21 @@ void CGameControllerBomb::EndBombRound(bool RealEnd)
 				GameServer()->SendChat(-1, TEAM_ALL, aBuf);
 				m_aPlayers[i].m_Score += g_Config.m_BombtagScoreForWinning;
 				GameServer()->m_apPlayers[i]->m_Score = m_aPlayers[i].m_Score;
+				if(g_Config.m_BombtagMysteryChance && rand() % 101 <= g_Config.m_BombtagMysteryChance)
+				{
+					const char *pLine = GameServer()->Server()->GetMysteryRoundLine();
+					if(pLine)
+					{
+						GameServer()->SendChat(-1, TEAM_ALL, "MYSTERY ROUND!");
+						GameServer()->Console()->ExecuteLine(pLine);
+						m_WasMysteryRound = true;
+					}
+				}
+				else if(m_WasMysteryRound)
+				{
+					GameServer()->Console()->ExecuteFile(g_Config.m_SvMysteryRoundsResetFileName);
+					m_WasMysteryRound = false;
+				}
 				break;
 			}
 		}

--- a/src/game/server/gamemodes/Bomb.h
+++ b/src/game/server/gamemodes/Bomb.h
@@ -70,5 +70,6 @@ public:
 
 	void OnTakeDamage(int Dmg, int From, int To, int Weapon) override;
 	void OnSkinChange(const char *pSkin, bool UseCustomColor, int ColorBody, int ColorFeet, int ClientId) override;
+	bool m_WasMysteryRound = false;
 };
 #endif // GAME_SERVER_GAMEMODES_BOMB_H


### PR DESCRIPTION
New commands and their defaults:
bombtag_mystery_chance 0
sv_mysteryrounds_filename mysteryrounds.txt
sv_mysteryrounds_reset_filename mysteryrounds_reset.txt


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
